### PR TITLE
Metatags break graphiql

### DIFF
--- a/src/Plugin/GraphQL/Interfaces/Metatag.php
+++ b/src/Plugin/GraphQL/Interfaces/Metatag.php
@@ -7,7 +7,9 @@ use Drupal\graphql\Plugin\GraphQL\Interfaces\InterfacePluginBase;
 /**
  * @GraphQLInterface(
  *   id = "meta_tag",
- *   name = "Metatag"
+ *   name = "Metatag",
+ *   type = "metatag",
+ *   description = @Translation("Metatag interface containing metatag properties.")
  * )
  */
 class Metatag extends InterfacePluginBase {


### PR DESCRIPTION
fix issue with metatags breaking the graphiql explorer