### PR TITLE
Add support for schema metatags

### DIFF
--- a/src/Plugin/GraphQL/Fields/Entity/EntitySchemaMetatags.php
+++ b/src/Plugin/GraphQL/Fields/Entity/EntitySchemaMetatags.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\graphql_metatag\Plugin\GraphQL\Fields\Entity;
+
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * @GraphQLField(
+ *   id = "entity_schema_metatags",
+ *   name = "entitySchemaMetatags",
+ *   type = "[SchemaMetatag]",
+ *   description = @Translation("Loads schema.org defined metatags for the entity"),
+ *   parents = {"Entity"}
+ * )
+ */
+class EntitySchemaMetatags extends EntityMetatags {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
+    if ($value instanceof ContentEntityInterface) {
+      $tags = $this->metatagManager->tagsFromEntityWithDefaults($value);
+
+      // Process only schema metatags.
+      $elements = $this->metatagManager->generateRawElements($tags, $value);
+      $elements = array_filter($elements, function ($metatag_object) {
+        return NestedArray::getValue($metatag_object, ['#attributes', 'schema_metatag']) === TRUE;
+      });
+
+      foreach ($elements as $element) {
+        yield $element;
+      }
+    }
+  }
+
+}

--- a/src/Plugin/GraphQL/Fields/Entity/EntitySchemaMetatags.php
+++ b/src/Plugin/GraphQL/Fields/Entity/EntitySchemaMetatags.php
@@ -9,6 +9,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 
 /**
  * @GraphQLField(
+ *   secure = true,
  *   id = "entity_schema_metatags",
  *   name = "entitySchemaMetatags",
  *   type = "[SchemaMetatag]",

--- a/src/Plugin/GraphQL/Fields/InternalUrl/Metatags.php
+++ b/src/Plugin/GraphQL/Fields/InternalUrl/Metatags.php
@@ -14,6 +14,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @GraphQLField(
+ *   secure = true,
  *   id = "url_metatags",
  *   name = "metatags",
  *   type = "[Metatag]",

--- a/src/Plugin/GraphQL/Fields/InternalUrl/Metatags.php
+++ b/src/Plugin/GraphQL/Fields/InternalUrl/Metatags.php
@@ -74,7 +74,6 @@ class Metatags extends FieldPluginBase implements ContainerFactoryPluginInterfac
         $tags = metatag_get_tags_from_route();
         $tags = NestedArray::getValue($tags, ['#attached', 'html_head']) ?: [];
 
-        // TODO: Filter non schema ones.
         $tags = array_filter($tags, function ($tag) {
           return is_array($tag) &&
             !NestedArray::getValue($tag, [0, '#attributes', 'schema_metatag']);

--- a/src/Plugin/GraphQL/Fields/InternalUrl/SchemaMetatags.php
+++ b/src/Plugin/GraphQL/Fields/InternalUrl/SchemaMetatags.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\graphql_metatag\Plugin\GraphQL\Fields\InternalUrl;
+
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Url;
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * @GraphQLField(
+ *   id = "url_schema_metatags",
+ *   name = "schema_metatags",
+ *   type = "[SchemaMetatag]",
+ *   description = @Translation("Loads schema.org defined metatags for the URL"),
+ *   parents = {"InternalUrl", "EntityCanonicalUrl"}
+ * )
+ */
+class SchemaMetatags extends Metatags {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
+    if ($value instanceof Url) {
+      $resolve = $this->subRequestBuffer->add($value, function () {
+        $tags = metatag_get_tags_from_route();
+        $tags = NestedArray::getValue($tags, ['#attached', 'html_head']) ?: [];
+
+        $tags = array_filter($tags, function ($tag) {
+          return is_array($tag) &&
+            NestedArray::getValue($tag, [0, '#attributes', 'schema_metatag']) === TRUE;
+        });
+
+        return array_map('reset', $tags);
+      });
+
+      return function ($value, array $args, ResolveContext $context, ResolveInfo $info) use ($resolve) {
+        $tags = $resolve();
+        foreach ($tags->getValue() as $tag) {
+          yield $tag;
+        }
+      };
+    }
+  }
+
+}

--- a/src/Plugin/GraphQL/Fields/InternalUrl/SchemaMetatags.php
+++ b/src/Plugin/GraphQL/Fields/InternalUrl/SchemaMetatags.php
@@ -9,6 +9,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 
 /**
  * @GraphQLField(
+ *   secure = true,
  *   id = "url_schema_metatags",
  *   name = "schema_metatags",
  *   type = "[SchemaMetatag]",

--- a/src/Plugin/GraphQL/Fields/Metatag/Content.php
+++ b/src/Plugin/GraphQL/Fields/Metatag/Content.php
@@ -8,6 +8,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 
 /**
  * @GraphQLField(
+ *   secure = true,
  *   id = "metatag_content",
  *   name = "content",
  *   type = "String",

--- a/src/Plugin/GraphQL/Fields/Metatag/Content.php
+++ b/src/Plugin/GraphQL/Fields/Metatag/Content.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\graphql_metatag\Plugin\GraphQL\Fields\Metatag;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Fields\FieldPluginBase;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * @GraphQLField(
+ *   id = "metatag_content",
+ *   name = "content",
+ *   type = "String",
+ *   description = @Translation("The JSON encoded content of a schema metatag"),
+ *   parents = {"SchemaMetatag"}
+ * )
+ */
+class Content extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
+    yield json_encode($value['#attributes']['content']);
+  }
+
+}

--- a/src/Plugin/GraphQL/Fields/Metatag/Key.php
+++ b/src/Plugin/GraphQL/Fields/Metatag/Key.php
@@ -22,7 +22,10 @@ class Key extends FieldPluginBase {
    */
   protected function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
     if (isset($value['#tag']) && $value['#tag'] === 'meta') {
-      yield isset($value['#attributes']['property']) ? $value['#attributes']['property'] : $value['#attributes']['name'];
+      yield isset($value['#attributes']['property']) ? $value['#attributes']['property'] :
+        ((isset($value['#attributes']['http-equiv'])) ? $value['#attributes']['http-equiv'] :
+          ((isset($value['#attributes']['itemprop'])) ? $value['#attributes']['itemprop'] : $value['#attributes']['name'])
+        );
     }
     else if (isset($value['#tag']) && $value['#tag'] === 'link') {
       yield $value['#attributes']['rel'];

--- a/src/Plugin/GraphQL/Fields/Metatag/Key.php
+++ b/src/Plugin/GraphQL/Fields/Metatag/Key.php
@@ -12,7 +12,7 @@ use GraphQL\Type\Definition\ResolveInfo;
  *   id = "metatag_key",
  *   name = "key",
  *   type = "String",
- *   parents = {"Metatag"}
+ *   parents = {"Metatag", "SchemaMetatag"}
  * )
  */
 class Key extends FieldPluginBase {

--- a/src/Plugin/GraphQL/Interfaces/SchemaMetatag.php
+++ b/src/Plugin/GraphQL/Interfaces/SchemaMetatag.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\graphql_metatag\Plugin\GraphQL\Interfaces;
+
+use Drupal\graphql\Plugin\GraphQL\Interfaces\InterfacePluginBase;
+
+/**
+ * @GraphQLInterface(
+ *   id = "schema_meta_tag",
+ *   name = "SchemaMetatag",
+ *   type = "schema_metatag",
+ *   description = @Translation("SchemaMetatag interface containing schema metatag properties.")
+ * )
+ */
+class SchemaMetatag extends InterfacePluginBase {
+
+}

--- a/src/Plugin/GraphQL/Types/MetaHttpEquiv.php
+++ b/src/Plugin/GraphQL/Types/MetaHttpEquiv.php
@@ -8,21 +8,19 @@ use GraphQL\Type\Definition\ResolveInfo;
 
 /**
  * @GraphQLType(
- *   id = "meta_value",
- *   name = "MetaValue",
+ *   id = "meta_http_equiv",
+ *   name = "MetaHttpEquiv",
  *   interfaces = {"Metatag"}
  * )
  */
-class MetaValue extends TypePluginBase {
+class MetaHttpEquiv extends TypePluginBase {
 
   /**
    * {@inheritdoc}
    */
   public function applies($object, ResolveContext $context, ResolveInfo $info = NULL) {
     if (isset($object['#tag']) && $object['#tag'] === 'meta') {
-      return !array_key_exists('property', $object['#attributes'])
-        && !array_key_exists('http-equiv', $object['#attributes'])
-        && !array_key_exists('itemprop', $object['#attributes']);
+      return array_key_exists('http-equiv', $object['#attributes']);
     }
 
     return FALSE;

--- a/src/Plugin/GraphQL/Types/MetaItemProp.php
+++ b/src/Plugin/GraphQL/Types/MetaItemProp.php
@@ -27,4 +27,4 @@ class MetaItemProp extends TypePluginBase {
   }
 
 }
-AcquiaLiftMetaTags.php
+

--- a/src/Plugin/GraphQL/Types/MetaItemProp.php
+++ b/src/Plugin/GraphQL/Types/MetaItemProp.php
@@ -8,24 +8,23 @@ use GraphQL\Type\Definition\ResolveInfo;
 
 /**
  * @GraphQLType(
- *   id = "meta_value",
- *   name = "MetaValue",
+ *   id = "meta_item_prop",
+ *   name = "MetaItemProp",
  *   interfaces = {"Metatag"}
  * )
  */
-class MetaValue extends TypePluginBase {
+class MetaItemProp extends TypePluginBase {
 
   /**
    * {@inheritdoc}
    */
   public function applies($object, ResolveContext $context, ResolveInfo $info = NULL) {
     if (isset($object['#tag']) && $object['#tag'] === 'meta') {
-      return !array_key_exists('property', $object['#attributes'])
-        && !array_key_exists('http-equiv', $object['#attributes'])
-        && !array_key_exists('itemprop', $object['#attributes']);
+      return array_key_exists('itemprop', $object['#attributes']);
     }
 
     return FALSE;
   }
 
 }
+AcquiaLiftMetaTags.php

--- a/src/Plugin/GraphQL/Types/SchemaMeta.php
+++ b/src/Plugin/GraphQL/Types/SchemaMeta.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\graphql_metatag\Plugin\GraphQL\Types;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Types\TypePluginBase;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * @GraphQLType(
+ *   id = "schema_meta",
+ *   name = "SchemaMeta",
+ *   description = @Translation("Container for schema metatag properties.")
+ *   interfaces = {"SchemaMetatag"}
+ * )
+ */
+class SchemaMeta extends TypePluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies($object, ResolveContext $context, ResolveInfo $info = NULL) {
+    return TRUE;
+  }
+
+}

--- a/src/Plugin/GraphQL/Types/SchemaMeta.php
+++ b/src/Plugin/GraphQL/Types/SchemaMeta.php
@@ -10,7 +10,7 @@ use GraphQL\Type\Definition\ResolveInfo;
  * @GraphQLType(
  *   id = "schema_meta",
  *   name = "SchemaMeta",
- *   description = @Translation("Container for schema metatag properties.")
+ *   description = @Translation("Container for schema metatag properties."),
  *   interfaces = {"SchemaMetatag"}
  * )
  */


### PR DESCRIPTION
Fixes #6 

Here is proposal for exposing schema metatags. I split base metatags and schema metatags into two fields, because it's easier to manage that on frontend part too.

To query schema metatags, I just add field for entity:
```
schema_metatags: entitySchemaMetatags {
        key
        content
}
```

and after that map values to object like this:
```
<script type="application/ld+json">
  {JSON.stringify({
    '@context': 'https://schema.org',
    '@graph': [
      schema_metatags.reduce((res, entry) => {
        res[entry.key] = JSON.parse(entry.content);
        return res;
      }, {}),
    ],
  })}
</script>
```

And that's it.

Bad part is, that `content` is encoded json, but I would like to avoid too much nesting.