### PR TITLE
Mark metatag field for InternalUrl as secure.

### DIFF
--- a/src/Plugin/GraphQL/Fields/InternalUrl/Metatags.php
+++ b/src/Plugin/GraphQL/Fields/InternalUrl/Metatags.php
@@ -14,6 +14,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @GraphQLField(
+ *   secure = true,
  *   id = "url_metatags",
  *   name = "metatags",
  *   type = "[Metatag]",


### PR DESCRIPTION
One field missed in setting it as secure.