### PR TITLE
Allow modules to alter metatags

### DIFF
--- a/src/Plugin/GraphQL/Fields/InternalUrl/Metatags.php
+++ b/src/Plugin/GraphQL/Fields/InternalUrl/Metatags.php
@@ -71,8 +71,11 @@ class Metatags extends FieldPluginBase implements ContainerFactoryPluginInterfac
     if ($value instanceof Url) {
       $resolve = $this->subRequestBuffer->add($value, function () {
         $tags = metatag_get_tags_from_route();
+        // Trigger hook_metatags_attachments_alter().
+        // Allow modules to rendered metatags prior to attaching.
+        \Drupal::service('module_handler')->alter('metatags_attachments', $tags);
         $tags = NestedArray::getValue($tags, ['#attached', 'html_head']) ?: [];
-        $tags = array_filter($tags, function($tag) {
+        $tags = array_filter($tags, function ($tag) {
           return is_array($tag) && in_array(NestedArray::getValue($tag, [0, '#tag']), ['meta', 'link']);
         });
 


### PR DESCRIPTION
The module was not allowing meta tags to be altered by modules invoking the `hook_metatags_attachments_alter()`. This patch invokes that hook but also ensures that both `EntityMetatags` and `Metatags` are returning consistent output (they weren't) by calling the same function from the main metatag module and therefore allowing the hook to be implemented correctly.